### PR TITLE
Fix setuptools deprecation warnings for PyPI publication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Educational MCP server demonstrating FastMCP best practices - Complete learning guide with contributing guidelines and roadmap for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.12"
-license = {file = "LICENSE"}
+license = "MIT"
 authors = [
     {name = "Hugues Clouâtre", email = "hugues+mcp@linux.com"}
 ]
@@ -13,7 +13,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.12",
     "Topic :: Education",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
@@ -38,7 +37,7 @@ Contributing = "https://github.com/huguesclouatre/math-mcp-server/blob/main/CONT
 math-mcp-learning-server = "math_mcp.server:main"
 
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

This PR resolves all setuptools deprecation warnings that appeared during package building, ensuring the package is ready for clean PyPI publication with future-proof configuration.

## Changes Made

### License Configuration Modernization
- **Updated to SPDX format**: Changed from `license = {file = "LICENSE"}` to `license = "MIT"`
- **Removed deprecated classifier**: Eliminated `"License :: OSI Approved :: MIT License"` from classifiers
- **Future-proof**: Prevents breaking changes by February 2026 deadline

### Build System Optimization  
- **Removed unnecessary dependency**: Removed `"wheel"` from build requirements
- **Modern setuptools**: Wheel building is implicit in current setuptools versions

## Verification

✅ **Clean build confirmed**: 
- `uv build` now completes with **zero warnings**
- Both source distribution and wheel build successfully
- All deprecation warnings eliminated

## Impact

- **Immediate**: Clean PyPI publication without warnings
- **Future-proof**: Configuration compliant with upcoming setuptools requirements
- **Best practices**: Follows modern Python packaging standards

This ensures a professional PyPI package page with no build warnings for users installing the package.